### PR TITLE
Disable device's CNE_SYMLINK

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -27,7 +27,9 @@ $(CNE_SYMLINK): $(LOCAL_INSTALLED_MODULE)
 	@rm -rf $@
 	$(hide) ln -sf /product/etc/cne $@
 
-ALL_DEFAULT_INSTALLED_MODULES += $(CNE_SYMLINK)
+# region @maru
+# ALL_DEFAULT_INSTALLED_MODULES += $(CNE_SYMLINK)
+# endregion
 
 IMS_LIBS := libimscamera_jni.so libimsmedia_jni.so
 IMS_SYMLINKS := $(addprefix $(TARGET_OUT)/app/ims/lib/arm64/,$(notdir $(IMS_LIBS)))


### PR DESCRIPTION
The vendor/google_devices/bonito(or sargo) will copy files to system/etc/cne, and device's script will cause directory exists problems. This CL disables device's CNE_SYMLINK and leave it to vendor scripts.